### PR TITLE
feat: use state token for PDF viewer URL (DEV-1231)

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -129,15 +129,26 @@ Fliplet.Widget.instance('pdf-list', function(data) {
   $el.find('.list')
     .on('click', '.list-holder li', function(event) {
       var mediaId = $(this).attr('data-file-id');
-      var pdfUrl = [
-        Fliplet.Env.get('apiUrl'),
-        'v1/media/files/' + mediaId + '/pdf',
-        '?auth_token=' + Fliplet.User.getAuthToken()
-      ].join('');
-      Fliplet.Navigate.to({
-        action: 'url',
-        url: pdfUrl,
-        title: event.target.textContent
+      var title = event.target.textContent;
+
+      // Exchange the real session token for a one-time state token so that
+      // auth_token never appears in the URL opened by the PDF viewer.
+      Fliplet.API.request({
+        url: 'v1/session/authorize/state',
+        method: 'POST'
+      }).then(function(response) {
+        Fliplet.Navigate.to({
+          action: 'url',
+          url: Fliplet.Env.get('apiUrl') + 'v1/media/files/' + mediaId + '/pdf?state=' + response.state,
+          title: title
+        });
+      }).catch(function() {
+        // Fallback for environments where the state token endpoint is not yet deployed.
+        Fliplet.Navigate.to({
+          action: 'url',
+          url: Fliplet.Env.get('apiUrl') + 'v1/media/files/' + mediaId + '/pdf?auth_token=' + Fliplet.User.getAuthToken(),
+          title: title
+        });
       });
     });
 });


### PR DESCRIPTION
## Summary

Exchanges the user's session token for a one-shot state token via `POST /v1/session/authorize/state` before opening a PDF in the in-app browser. The PDF viewer URL now carries `?state=<UUID>` instead of `?auth_token=…`, so the auth token never appears in URL bars, browser history, or any logs the in-app browser may emit.

Keeps a `?auth_token=` catch-block fallback for environments where the state-token endpoint is not yet deployed (per Phase 2 scoping policy on existing Phase 1 fallbacks — keep as-is).

## Origin

This change was prepared during Phase 1 (DEV-1231) but never committed. Shipping it as part of Phase 2.

## Base branch

Targeting `master`. This widget has no `projects/DEV-1231` branch and deploys via the widget registry on push-to-master.

## Sibling PRs

- API side: Fliplet/fliplet-api#8165 — the state-token endpoint (already on `projects/DEV-1231` from Phase 1)
- Studio side: Fliplet/fliplet-studio#8615
- service-browser: Fliplet/fliplet-service-browser#38
- app-wrapping: Fliplet/fliplet-app-wrapping#320

## Test plan

Full plan: `/home/dev/projects/DEV-1231-test-plan.md`. Section relevant to this PR:

- [ ] §9 PDF list widget — tap a PDF entry, viewer opens, URL has `?state=` not `?auth_token=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)